### PR TITLE
Add basic wifi support

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "app_main.c" INCLUDE_DIRS "")
+idf_component_register(SRCS "app_main.c" "wifi.c" INCLUDE_DIRS "")

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -40,4 +40,23 @@ menu "ProgressBar Configuration"
         int "I2c Master Timeout"
         default 1000
 
+    config WIFI_AP_NAME
+        string "WiFi AP Name"
+        default "ProgressBar"
+        help
+            Access point name for WiFi provisioning
+
+    config WIFI_AP_PASS
+        string "WiFi AP Password"
+        default "beertime"
+        help
+            Access point password for WiFi provisioning
+
+    config WIFI_PROV_POP
+        string "WiFi POP"
+        default "beertime"
+        help
+            Any device that want's to provision us with WiFi credentials needs proper authorization.
+            This is accomplished by the device authorizing itself to us with a Proof of Possession Key/Password.
+
 endmenu

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -9,4 +9,6 @@ void app_main(void) {
     int result = rust_main();
 
     ESP_LOGI(TAG, "Rust returned code: %d", result);
+
+    provision_wifi();
 }

--- a/main/app_main.h
+++ b/main/app_main.h
@@ -1,5 +1,6 @@
 #pragma once
 
 #include "esp_log.h"
+#include "wifi.h"
 
 extern int rust_main(void);

--- a/main/wifi.c
+++ b/main/wifi.c
@@ -1,0 +1,144 @@
+#include "wifi.h"
+
+/* This tag will be prefixed to the log messages */
+static const char *TAG = "wifi";
+
+const static int WIFI_CONNECTED_EVENT = BIT0;
+static EventGroupHandle_t wifi_event_group;
+
+static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data)
+{
+    static int retries;
+    if (event_base == WIFI_PROV_EVENT) {
+        switch (event_id) {
+            case WIFI_PROV_START:
+                ESP_LOGI(TAG, "Provisioning started");
+                break;
+            case WIFI_PROV_CRED_RECV: {
+                wifi_sta_config_t *wifi_sta_cfg = (wifi_sta_config_t *)event_data;
+                ESP_LOGI(TAG, "Received Wi-Fi credentials"
+                         "\n\tSSID     : %s\n\tPassword : %s",
+                         (const char *) wifi_sta_cfg->ssid,
+                         (const char *) wifi_sta_cfg->password);
+                break;
+            }
+            case WIFI_PROV_CRED_FAIL: {
+                wifi_prov_sta_fail_reason_t *reason = (wifi_prov_sta_fail_reason_t *)event_data;
+                ESP_LOGE(TAG, "Provisioning failed!\n\tReason : %s"
+                         "\n\tPlease reset to factory and retry provisioning",
+                         (*reason == WIFI_PROV_STA_AUTH_ERROR) ?
+                         "Wi-Fi station authentication failed" : "Wi-Fi access-point not found");
+                retries++;
+                if (retries >= 5) {
+                    ESP_LOGI(TAG, "Failed to connect with provisioned AP, reseting provisioned credentials");
+                    wifi_prov_mgr_reset_sm_state_on_failure();
+                    retries = 0;
+                }
+                break;
+            }
+            case WIFI_PROV_CRED_SUCCESS:
+                ESP_LOGI(TAG, "Provisioning successful");
+                retries = 0;
+                break;
+            case WIFI_PROV_END:
+                /* De-initialize manager once provisioning is finished */
+                wifi_prov_mgr_deinit();
+                break;
+            default:
+                break;
+        }
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
+        ESP_LOGI(TAG, "Connected with IP Address:" IPSTR, IP2STR(&event->ip_info.ip));
+        /* Signal main application to continue execution */
+        xEventGroupSetBits(wifi_event_group, WIFI_CONNECTED_EVENT);
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        ESP_LOGI(TAG, "Disconnected. Connecting to the AP again...");
+        esp_wifi_connect();
+    }
+}
+
+static void wifi_init_sta(void)
+{
+    /* Start Wi-Fi in station mode */
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_start());
+}
+
+void provision_wifi(void)
+{
+    /* Initialize NVS partition */
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        /* NVS partition was truncated
+         * and needs to be erased */
+        ESP_ERROR_CHECK(nvs_flash_erase());
+
+        /* Retry nvs_flash_init */
+        ESP_ERROR_CHECK(nvs_flash_init());
+    }
+
+    /* Initialize TCP/IP */
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    /* Initialize the event loop */
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    wifi_event_group = xEventGroupCreate();
+
+    /* Register our event handler for Wi-Fi, IP and Provisioning related events */
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_PROV_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL));
+
+    /* Initialize Wi-Fi including netif with default config */
+    esp_netif_create_default_wifi_sta();
+    esp_netif_create_default_wifi_ap();
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    /* Configuration for the provisioning manager */
+    wifi_prov_mgr_config_t config = {
+        .scheme = wifi_prov_scheme_softap,
+        .scheme_event_handler = WIFI_PROV_EVENT_HANDLER_NONE
+    };
+
+    /* Initialize provisioning manager with the
+     * configuration parameters set above */
+    ESP_ERROR_CHECK(wifi_prov_mgr_init(config));
+
+    bool provisioned = false;
+    /* WiFi credentials are saved in NVS and we could therefore be already provisioned. Let's check it out */
+    ESP_ERROR_CHECK(wifi_prov_mgr_is_provisioned(&provisioned));
+
+    /* If device is not yet provisioned start provisioning service */
+    if (!provisioned) {
+        ESP_LOGI(TAG, "Starting provisioning");
+
+        char *service_name = CONFIG_WIFI_AP_NAME;
+
+        wifi_prov_security_t security = WIFI_PROV_SECURITY_1;
+
+        /* Proof-of-Possesion */
+        const char *pop = CONFIG_WIFI_PROV_POP;
+
+        /* SoftAP password */
+        const char *service_key = CONFIG_WIFI_AP_PASS;
+
+        /* Start provisioning service */
+        ESP_ERROR_CHECK(wifi_prov_mgr_start_provisioning(security, pop, service_name, service_key));
+    } else {
+        ESP_LOGI(TAG, "Already provisioned, starting Wi-Fi STA");
+
+        /* We don't need the manager as device is already provisioned,
+         * so let's release it's resources */
+        wifi_prov_mgr_deinit();
+
+        /* Start Wi-Fi station */
+        wifi_init_sta();
+    }
+
+    /* Wait for Wi-Fi connection */
+    xEventGroupWaitBits(wifi_event_group, WIFI_CONNECTED_EVENT, false, true, portMAX_DELAY);
+}

--- a/main/wifi.h
+++ b/main/wifi.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdio.h>
+#include <string.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/event_groups.h>
+
+#include <esp_log.h>
+#include <esp_wifi.h>
+#include <esp_event.h>
+#include <nvs_flash.h>
+
+#include <wifi_provisioning/manager.h>
+#include <wifi_provisioning/scheme_softap.h>
+
+void provision_wifi(void);


### PR DESCRIPTION
This adds the basic wifi code with esps wifi manager. It uses protocomm with the SoftAP provisioning app to securely transfer the wifi credentials over.

Resolves #12 