### PR TITLE
Remove redundant commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = {extends: ['@commitlint/config-conventional']}


### PR DESCRIPTION
As we only used the default, we can also fully remove this file.