### PR TITLE
Pin dagger version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,9 @@ jobs:
           echo "DAGGER_CACHE_FROM=type=gha,scope=${{env.DAGGER_CACHE_BASE}}-main type=gha,scope=${{env.DAGGER_CACHE_BASE}}-${{github.event.number}}" >> $GITHUB_ENV
         if: ${{ github.event_name == 'pull_request' }}
       - name: Build firmware
-        uses: dagger/dagger-for-github@v3
+        uses: dagger/dagger-for-github@v3.1.0
         with:
+          version: v0.2.36
           cmds: |
             project update
             do build


### PR DESCRIPTION
The dagger-for-github action is undergoing a lot of changes and might even be deprecated. Work around this by installing dagger manually.

EDIT: Turns out this isn't as easy as expected, just pin the version for now.